### PR TITLE
allow user to set daemonThread for thread factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This appender pushes log messages to a Redis list. Here is an example configurat
     log4j.appender.redis.batchSize=100
     log4j.appender.redis.purgeOnFailure=true
     log4j.appender.redis.alwaysBatch=true
+    log4j.appender.redis.daemonThread=true
 
 Where:
 
@@ -30,6 +31,7 @@ Where:
 * **batchSize** (optional, default: 100) the number of log messages to send in a single `RPUSH` command
 * **purgeOnFailure** (optional, default: true) whether to purge the enqueued log messages if an error occurs attempting to connect to redis, thus preventing the memory usage from becoming too high
 * **alwaysBatch** (optional, default: true) whether to wait for a full batch. if true, will only send once there are `batchSize` log messages enqueued
+* **daemonThread** (optional, default: true) whether to launch the appender thread as a daemon thread
 
 ### Maven
 

--- a/src/main/java/com/ryantenney/log4j/NamedThreadFactory.java
+++ b/src/main/java/com/ryantenney/log4j/NamedThreadFactory.java
@@ -8,21 +8,23 @@ class NamedThreadFactory implements ThreadFactory {
 
 	private final String prefix;
 	private final ThreadFactory threadFactory;
-
+  private final boolean daemonThread;
 	private final AtomicInteger counter = new AtomicInteger();
 
-	public NamedThreadFactory(final String prefix) {
-		this(prefix, Executors.defaultThreadFactory());
+	public NamedThreadFactory(final String prefix, final boolean daemonThread) {
+		this(prefix, daemonThread, Executors.defaultThreadFactory());
 	}
 
-	public NamedThreadFactory(final String prefix, final ThreadFactory threadFactory) {
+	public NamedThreadFactory(final String prefix, final boolean daemonThread, final ThreadFactory threadFactory) {
 		this.prefix = prefix;
 		this.threadFactory = threadFactory;
+    this.daemonThread = daemonThread;
 	}
 
 	@Override
 	public Thread newThread(Runnable r) {
 		Thread t = this.threadFactory.newThread(r);
+    t.setDaemon(this.daemonThread);
 		t.setName(this.prefix + "-Thread-" + this.counter.incrementAndGet());
 		return t;
 	}

--- a/src/main/java/com/ryantenney/log4j/RedisAppender.java
+++ b/src/main/java/com/ryantenney/log4j/RedisAppender.java
@@ -51,6 +51,7 @@ public class RedisAppender extends AppenderSkeleton implements Runnable {
 	private long period = 500;
 	private boolean alwaysBatch = true;
 	private boolean purgeOnFailure = true;
+  private boolean daemonThread = true;
 
 	private int messageIndex = 0;
 	private Queue<LoggingEvent> events;
@@ -68,7 +69,7 @@ public class RedisAppender extends AppenderSkeleton implements Runnable {
 
 			if (key == null) throw new IllegalStateException("Must set 'key'");
 
-			if (executor == null) executor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("RedisAppender"));
+			if (executor == null) executor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("RedisAppender", daemonThread));
 
 			if (task != null && !task.isDone()) task.cancel(true);
 			if (jedis != null && jedis.isConnected()) jedis.disconnect();
@@ -209,5 +210,9 @@ public class RedisAppender extends AppenderSkeleton implements Runnable {
 	public boolean requiresLayout() {
 		return true;
 	}
+
+  public void setDaemonThread(boolean daemonThread){
+    this.daemonThread = daemonThread;
+  }
 
 }


### PR DESCRIPTION
We ran into a problem where we had many, many workers staying alive because the redis appender thread was blocking. This allows the user to specify if it should be a daemon thread or not.
