### PR TITLE
Reconnect on socket closed

### DIFF
--- a/src/main/java/com/ryantenney/log4j/RedisAppender.java
+++ b/src/main/java/com/ryantenney/log4j/RedisAppender.java
@@ -177,9 +177,13 @@ public class RedisAppender extends AppenderSkeleton implements Runnable {
 			messageIndex = 0;
 		} catch (JedisConnectionException e) {
 			LogLog.warn("Lost connection to Redis: " + e.getMessage());
+			jedis.disconnect();
 			if (connect()) {
 				push();
 			}
+		} catch (ArrayIndexOutOfBoundsException e) {
+			events.clear();
+			messageIndex = 0;
 		}
 	}
 


### PR DESCRIPTION
When sending logs to Redis instances behind a loadbalancer, sometimes it closes the socket when balancing the connections. This small patch does a reconnect on such an event.
