### PR TITLE
Use relevant project version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Where:
 <dependency>
 	<groupId>com.ryantenney.log4j</groupId>
 	<artifactId>redis-appender</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Config option `daemonThread` is applicable only to the new version.
