### PR TITLE
Fixed a possible OutOfMemoryError and a NullPointerException

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This appender pushes log messages to a Redis list. Here is an example configurat
     log4j.appender.redis.purgeOnFailure=true
     log4j.appender.redis.alwaysBatch=true
     log4j.appender.redis.daemonThread=true
+    log4j.appender.redis.maxEvents=10000
 
 Where:
 
@@ -32,6 +33,7 @@ Where:
 * **purgeOnFailure** (optional, default: true) whether to purge the enqueued log messages if an error occurs attempting to connect to redis, thus preventing the memory usage from becoming too high
 * **alwaysBatch** (optional, default: true) whether to wait for a full batch. if true, will only send once there are `batchSize` log messages enqueued
 * **daemonThread** (optional, default: true) whether to launch the appender thread as a daemon thread
+* **maxEvents** (optional, default: Integer.MAX\_VALUE) the maximum number of log4j events to accept when Redis is unresponsive
 
 ### Maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+	    <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/ryantenney/log4j/RedisAppender.java
+++ b/src/main/java/com/ryantenney/log4j/RedisAppender.java
@@ -25,9 +25,6 @@
 
 package com.ryantenney.log4j;
 
-import java.util.Arrays;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -38,12 +35,10 @@ import org.apache.log4j.helpers.LogLog;
 import org.apache.log4j.spi.ErrorCode;
 import org.apache.log4j.spi.LoggingEvent;
 
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
-import redis.clients.util.SafeEncoder;
 
-public class RedisAppender extends AppenderSkeleton implements Runnable {
+public class RedisAppender extends AppenderSkeleton {
 
 	private String host = "localhost";
 	private int port = 6379;
@@ -71,18 +66,13 @@ public class RedisAppender extends AppenderSkeleton implements Runnable {
     private boolean testOnReturn = false;
     private int connectionPoolRetryCount = 2;
 
-
-
-
-	private int messageIndex = 0;
-    private JedisPool jedis;
-	private Queue<LoggingEvent> events;
-	private byte[][] batch;
-
-	//private Jedis jedis;
+    private JedisPool jedisPool;
 
 	private ScheduledExecutorService executor;
 	private ScheduledFuture<?> task;
+
+
+    private RedisAppenderRunnable redisAppenderRunnable;
 
 	@Override
 	public void activateOptions() {
@@ -95,11 +85,15 @@ public class RedisAppender extends AppenderSkeleton implements Runnable {
 
 			if (task != null && !task.isDone()) task.cancel(true);
 
-            events = new ConcurrentLinkedQueue<LoggingEvent>();
-			batch = new byte[batchSize][];
-			messageIndex = 0;
+            redisAppenderRunnable = new RedisAppenderRunnable();
+            redisAppenderRunnable.setBatchSize(batchSize);
+            redisAppenderRunnable.setLayout(layout);
+            redisAppenderRunnable.setErrorHandler(errorHandler);
+            redisAppenderRunnable.setAlwaysBatch(alwaysBatch);
+            redisAppenderRunnable.setJedisPool(jedisPool);
+            redisAppenderRunnable.setConnectionPoolRetryCount(connectionPoolRetryCount);
+            redisAppenderRunnable.setPurgeOnFailure(purgeOnFailure);
 
-			//jedis = new Jedis(host, port);
             JedisPoolConfig poolConfig = new JedisPoolConfig();
             if (lifo) {
                 poolConfig.setLifo(lifo);
@@ -139,12 +133,12 @@ public class RedisAppender extends AppenderSkeleton implements Runnable {
             }
 
             if (password!=null && password.length()>0) {
-                jedis  = new JedisPool(poolConfig,host,port,timeout,password);
+                jedisPool = new JedisPool(poolConfig,host,port,timeout,password);
             } else {
-                jedis  = new JedisPool(poolConfig,host,port,timeout);
+                jedisPool = new JedisPool(poolConfig,host,port,timeout);
             }
 
-			task = executor.scheduleWithFixedDelay(this, period, period, TimeUnit.MILLISECONDS);
+			task = executor.scheduleWithFixedDelay(redisAppenderRunnable, period, period, TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
 			LogLog.error("RedisAppender: Error during activateOptions", e);
 		}
@@ -154,7 +148,7 @@ public class RedisAppender extends AppenderSkeleton implements Runnable {
 	protected void append(LoggingEvent event) {
 		try {
 			populateEvent(event);
-			events.add(event);
+            redisAppenderRunnable.add(event);
 		} catch (Exception e) {
 			errorHandler.error("Error populating event and adding Redis to queue", e, ErrorCode.GENERIC_FAILURE, event);
 		}
@@ -174,77 +168,11 @@ public class RedisAppender extends AppenderSkeleton implements Runnable {
 		try {
 			task.cancel(false);
 			executor.shutdown();
-
 		} catch (Exception e) {
 			errorHandler.error(e.getMessage(), e, ErrorCode.CLOSE_FAILURE);
 		}
 	}
 
-	public void run() {
-
-
-		try {
-			if (messageIndex == batchSize) push();
-
-			LoggingEvent event;
-			while ((event = events.poll()) != null) {
-				try {
-					String message = layout.format(event);
-					batch[messageIndex++] = SafeEncoder.encode(message);
-				} catch (Exception e) {
-					errorHandler.error(e.getMessage(), e, ErrorCode.GENERIC_FAILURE, event);
-				}
-
-				if (messageIndex == batchSize) push();
-			}
-
-			if (!alwaysBatch && messageIndex > 0) push();
-		} catch (Exception e) {
-			errorHandler.error(e.getMessage(), e, ErrorCode.WRITE_FAILURE);
-		}
-	}
-
-	private void push() {
-		LogLog.debug("Sending " + messageIndex + " log messages to Redis");
-        Jedis connection = jedis.getResource();
-        try {
-            // this may all be unnecessary with the pooling set up right just being super cautious
-            if (!connection.isConnected()) {
-                jedis.returnBrokenResource(connection);
-                for (int i = 0; i < connectionPoolRetryCount; i++) {
-                    connection = jedis.getResource();
-                    if (connection.isConnected()) {
-                        break;
-                    } else {
-                        if (i >= connectionPoolRetryCount) {
-                            // something wrong
-                            if (purgeOnFailure) {
-                                LogLog.debug("Purging Redis event queue");
-                                events.clear();
-                                messageIndex = 0;
-                            }
-                            jedis.returnBrokenResource(connection);
-                            LogLog.error("Error during getting connection from pool check your Redis settings");
-                            return;
-                        }
-                    }
-
-                }
-
-            }
-            connection.rpush(SafeEncoder.encode(key),
-                batchSize == messageIndex
-                ? batch
-                : Arrays.copyOf(batch, messageIndex));
-            messageIndex = 0;
-        } catch (Exception e) {
-            LogLog.error("Error pushing message list to Redis",e);
-        } finally {
-            if (connection!=null) {
-                jedis.returnResource(connection);
-            }
-        }
-    }
 
 	public void setHost(String host) {
 		this.host = host;

--- a/src/main/java/com/ryantenney/log4j/RedisAppender.java
+++ b/src/main/java/com/ryantenney/log4j/RedisAppender.java
@@ -85,15 +85,6 @@ public class RedisAppender extends AppenderSkeleton {
 
 			if (task != null && !task.isDone()) task.cancel(true);
 
-            redisAppenderRunnable = new RedisAppenderRunnable();
-            redisAppenderRunnable.setBatchSize(batchSize);
-            redisAppenderRunnable.setLayout(layout);
-            redisAppenderRunnable.setErrorHandler(errorHandler);
-            redisAppenderRunnable.setAlwaysBatch(alwaysBatch);
-            redisAppenderRunnable.setJedisPool(jedisPool);
-            redisAppenderRunnable.setConnectionPoolRetryCount(connectionPoolRetryCount);
-            redisAppenderRunnable.setPurgeOnFailure(purgeOnFailure);
-
             JedisPoolConfig poolConfig = new JedisPoolConfig();
             if (lifo) {
                 poolConfig.setLifo(lifo);
@@ -138,7 +129,17 @@ public class RedisAppender extends AppenderSkeleton {
                 jedisPool = new JedisPool(poolConfig,host,port,timeout);
             }
 
-			task = executor.scheduleWithFixedDelay(redisAppenderRunnable, period, period, TimeUnit.MILLISECONDS);
+            redisAppenderRunnable = new RedisAppenderRunnable();
+            redisAppenderRunnable.setBatchSize(batchSize);
+            redisAppenderRunnable.setLayout(layout);
+            redisAppenderRunnable.setErrorHandler(errorHandler);
+            redisAppenderRunnable.setAlwaysBatch(alwaysBatch);
+            redisAppenderRunnable.setJedisPool(jedisPool);
+            redisAppenderRunnable.setConnectionPoolRetryCount(connectionPoolRetryCount);
+            redisAppenderRunnable.setPurgeOnFailure(purgeOnFailure);
+            redisAppenderRunnable.setKey(key);
+
+            task = executor.scheduleWithFixedDelay(redisAppenderRunnable, period, period, TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
 			LogLog.error("RedisAppender: Error during activateOptions", e);
 		}

--- a/src/main/java/com/ryantenney/log4j/RedisAppender.java
+++ b/src/main/java/com/ryantenney/log4j/RedisAppender.java
@@ -65,6 +65,7 @@ public class RedisAppender extends AppenderSkeleton {
     private boolean testWhileIdle = false;
     private boolean testOnReturn = false;
     private int connectionPoolRetryCount = 2;
+    private int maxEvents = Integer.MAX_VALUE;
 
     private JedisPool jedisPool;
 
@@ -138,6 +139,7 @@ public class RedisAppender extends AppenderSkeleton {
             redisAppenderRunnable.setConnectionPoolRetryCount(connectionPoolRetryCount);
             redisAppenderRunnable.setPurgeOnFailure(purgeOnFailure);
             redisAppenderRunnable.setKey(key);
+            redisAppenderRunnable.setMaxEvents(maxEvents);
 
             task = executor.scheduleWithFixedDelay(redisAppenderRunnable, period, period, TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
@@ -325,5 +327,13 @@ public class RedisAppender extends AppenderSkeleton {
 
     public void setConnectionPoolRetryCount(int connectionPoolRetryCount) {
         this.connectionPoolRetryCount = connectionPoolRetryCount;
+    }
+
+    public void setMaxEvents(int maxEvents) {
+        this.maxEvents = maxEvents;
+    }
+
+    public int getMaxEvents() {
+        return maxEvents;
     }
 }

--- a/src/main/java/com/ryantenney/log4j/RedisAppenderRunnable.java
+++ b/src/main/java/com/ryantenney/log4j/RedisAppenderRunnable.java
@@ -31,6 +31,7 @@ public class RedisAppenderRunnable implements Runnable {
     private int connectionPoolRetryCount;
     private boolean purgeOnFailure;
     private String key;
+    private int maxEvents;
 
     private String lastExceptionMessage;
 
@@ -140,10 +141,20 @@ public class RedisAppenderRunnable implements Runnable {
     }
 
     public void add(LoggingEvent event) {
-        events.add(event);
+        if (events.size() < maxEvents) {
+            events.add(event);
+        }
+    }
+
+    long eventsSize() {
+        return events.size();
     }
 
     public void setKey(String key) {
         this.key = key;
+    }
+
+    public void setMaxEvents(int maxEvents) {
+        this.maxEvents = maxEvents;
     }
 }

--- a/src/main/java/com/ryantenney/log4j/RedisAppenderRunnable.java
+++ b/src/main/java/com/ryantenney/log4j/RedisAppenderRunnable.java
@@ -1,0 +1,130 @@
+package com.ryantenney.log4j;
+
+import org.apache.log4j.Layout;
+import org.apache.log4j.helpers.LogLog;
+import org.apache.log4j.spi.ErrorCode;
+import org.apache.log4j.spi.ErrorHandler;
+import org.apache.log4j.spi.LoggingEvent;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.util.SafeEncoder;
+
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Florian Hopf. mail@florian-hopf.de
+ */
+public class RedisAppenderRunnable implements Runnable {
+
+
+    private int batchSize;
+    private int messageIndex = 0;
+
+    private Queue<LoggingEvent> events = new ConcurrentLinkedQueue<LoggingEvent>();
+    private Layout layout;
+    private byte[][] batch = new byte[batchSize][];
+    private ErrorHandler errorHandler;
+    private boolean alwaysBatch;
+    private JedisPool jedisPool;
+    private int connectionPoolRetryCount;
+    private boolean purgeOnFailure;
+
+    public void run() {
+
+        try {
+            if (messageIndex == batchSize) push();
+
+            LoggingEvent event;
+            while ((event = events.poll()) != null) {
+                try {
+                    String message = layout.format(event);
+                    batch[messageIndex++] = SafeEncoder.encode(message);
+                } catch (Exception e) {
+                    errorHandler.error(e.getMessage(), e, ErrorCode.GENERIC_FAILURE, event);
+                }
+
+                if (messageIndex == batchSize) push();
+            }
+
+            if (!alwaysBatch && messageIndex > 0) push();
+        } catch (Exception e) {
+            errorHandler.error(e.getMessage(), e, ErrorCode.WRITE_FAILURE);
+        }
+    }
+
+    private void push() {
+        LogLog.debug("Sending " + messageIndex + " log messages to Redis");
+        Jedis connection = jedisPool.getResource();
+        try {
+            // this may all be unnecessary with the pooling set up right just being super cautious
+            if (!connection.isConnected()) {
+                jedisPool.returnBrokenResource(connection);
+                for (int i = 0; i < connectionPoolRetryCount; i++) {
+                    connection = jedisPool.getResource();
+                    if (connection.isConnected()) {
+                        break;
+                    } else {
+                        if (i >= connectionPoolRetryCount) {
+                            // something wrong
+                            if (purgeOnFailure) {
+                                LogLog.debug("Purging Redis event queue");
+                                events.clear();
+                                messageIndex = 0;
+                            }
+                            jedisPool.returnBrokenResource(connection);
+                            LogLog.error("Error during getting connection from pool check your Redis settings");
+                            return;
+                        }
+                    }
+
+                }
+
+            }
+            connection.rpush(SafeEncoder.encode(key),
+                    batchSize == messageIndex
+                            ? batch
+                            : Arrays.copyOf(batch, messageIndex));
+            messageIndex = 0;
+        } catch (Exception e) {
+            LogLog.error("Error pushing message list to Redis",e);
+        } finally {
+            if (connection!=null) {
+                jedisPool.returnResource(connection);
+            }
+        }
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public void setLayout(Layout layout) {
+        this.layout = layout;
+    }
+
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    public void setAlwaysBatch(boolean alwaysBatch) {
+        this.alwaysBatch = alwaysBatch;
+    }
+
+    public void setJedisPool(JedisPool jedisPool) {
+        this.jedisPool = jedisPool;
+    }
+
+    public void setConnectionPoolRetryCount(int connectionPoolRetryCount) {
+        this.connectionPoolRetryCount = connectionPoolRetryCount;
+    }
+
+    public void setPurgeOnFailure(boolean purgeOnFailure) {
+        this.purgeOnFailure = purgeOnFailure;
+    }
+
+    public void add(LoggingEvent event) {
+        events.add(event);
+    }
+}

--- a/src/test/java/com/ryantenney/log4j/RedisAppenderRunnableTest.java
+++ b/src/test/java/com/ryantenney/log4j/RedisAppenderRunnableTest.java
@@ -1,0 +1,117 @@
+package com.ryantenney.log4j;
+
+import org.apache.log4j.Layout;
+import org.apache.log4j.spi.ErrorHandler;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.util.SafeEncoder;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RedisAppenderRunnableTest {
+
+    private int batchSize = 10;
+
+    private RedisAppenderRunnable runnable;
+
+    @Mock
+    private ErrorHandler errorHandler;
+
+    @Mock
+    private JedisPool jedisPool;
+
+    @Mock
+    private Jedis jedis;
+
+    @Mock
+    private Layout layout;
+
+    @Before
+    public void setUp() {
+        runnable = new RedisAppenderRunnable();
+        runnable.setAlwaysBatch(false);
+        runnable.setBatchSize(batchSize);
+        runnable.setConnectionPoolRetryCount(0);
+        runnable.setErrorHandler(errorHandler);
+        runnable.setJedisPool(jedisPool);
+        runnable.setLayout(layout);
+        runnable.setKey("key");
+
+        when(jedisPool.getResource()).thenReturn(jedis);
+    }
+
+    @Test
+    public void batchIsPushedToRedis() {
+        for (int i = 0; i < 10; i++) {
+            runnable.add(loggingEvent(String.valueOf(i)));
+        }
+        runnable.run();
+
+        // capturing varargs unfortunately isn't possible with Mockito currently
+        // the messages are just encoded in their ASCII value
+        verify(jedis).rpush("key".getBytes(),
+                new byte[]{48}, new byte[]{49},
+                new byte[]{50}, new byte[]{51},
+                new byte[]{52}, new byte[]{53},
+                new byte[]{54}, new byte[]{55},
+                new byte[]{56}, new byte[]{57}
+        );
+    }
+
+    @Test
+    public void exceptionDuringPush() {
+        // sending the first ten will result in an Exception
+        // the additional message should be appended to the end
+        when(jedis.rpush("key".getBytes(),
+                new byte[]{48}, new byte[]{49},
+                new byte[]{50}, new byte[]{51},
+                new byte[]{52}, new byte[]{53},
+                new byte[]{54}, new byte[]{55},
+                new byte[]{56}, new byte[]{57}
+        )).thenThrow(new JedisDataException(""));
+
+        for (int i = 0; i < 10; i++) {
+            runnable.add(loggingEvent(String.valueOf(i)));
+        }
+        runnable.add(loggingEvent("foo"));
+
+        runnable.run();
+
+        verify(jedis).rpush("key".getBytes(),
+                new byte[]{48}, new byte[]{49},
+                new byte[]{50}, new byte[]{51},
+                new byte[]{52}, new byte[]{53},
+                new byte[]{54}, new byte[]{55},
+                new byte[]{56}, new byte[]{57}
+        );
+
+        // the last message should be overwritten
+        verify(jedis).rpush("key".getBytes(),
+                new byte[]{48}, new byte[]{49},
+                new byte[]{50}, new byte[]{51},
+                new byte[]{52}, new byte[]{53},
+                new byte[]{54}, new byte[]{55},
+                new byte[]{56}, "foo".getBytes()
+        );
+    }
+
+    private LoggingEvent loggingEvent(String text) {
+        LoggingEvent event = mock(LoggingEvent.class);
+        when(layout.format(event)).thenReturn(text);
+        return event;
+    }
+
+}

--- a/src/test/java/com/ryantenney/log4j/RedisAppenderRunnableTest.java
+++ b/src/test/java/com/ryantenney/log4j/RedisAppenderRunnableTest.java
@@ -15,6 +15,7 @@ import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.util.SafeEncoder;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 
 import static org.junit.Assert.assertNotNull;
@@ -48,6 +49,7 @@ public class RedisAppenderRunnableTest {
         runnable.setErrorHandler(errorHandler);
         runnable.setJedisPool(jedisPool);
         runnable.setLayout(layout);
+        runnable.setMaxEvents(Integer.MAX_VALUE);
         runnable.setKey("key");
 
         when(jedisPool.getResource()).thenReturn(jedis);
@@ -106,6 +108,16 @@ public class RedisAppenderRunnableTest {
                 new byte[]{54}, new byte[]{55},
                 new byte[]{56}, "foo".getBytes()
         );
+    }
+
+    @Test
+    public void maxEventsCanBeConfigured() {
+        runnable.setMaxEvents(10);
+        for (int i = 0; i < 11; i++) {
+            runnable.add(loggingEvent(String.valueOf(i)));
+        }
+
+        assertEquals(10, runnable.eventsSize());
     }
 
     private LoggingEvent loggingEvent(String text) {


### PR DESCRIPTION
When running the appender in production we noticed two more problems
- a NullPointerException when Redis ran full that could only be resolved by restarting the application
- another cause for OutOfMemoryErrror: allowing to accept too many LogEvents

This pull request fixes both. For the first fix a bit of refactoring was involved to make the code somehow testable.
